### PR TITLE
Fixed aligning overlayed image

### DIFF
--- a/app/src/main/java/hardingllc/pockethinman_android/MainActivity.java
+++ b/app/src/main/java/hardingllc/pockethinman_android/MainActivity.java
@@ -598,7 +598,10 @@ public class MainActivity extends AppCompatActivity {
 
         @Override
         public void onSurfaceTextureSizeChanged(SurfaceTexture surface, int width, int height) {
-
+            ViewGroup.LayoutParams params = imageView.getLayoutParams();
+            params.height = height;
+            params.width = width;
+            imageView.setLayoutParams(params);
         }
 
         @Override


### PR DESCRIPTION
The texture view gets resized when opening the camera capture session, so we need to resize the image view to match the new dimensions.